### PR TITLE
Improve UI spacing and rigidity

### DIFF
--- a/animal_gacha.html
+++ b/animal_gacha.html
@@ -7,7 +7,7 @@
 <style>
   :root{
     --bg:#0f1115; --panel:#161a22; --panel-2:#1d2330; --ink:#e7ecf3; --ink-dim:#aab6cc; --accent:#7dd3fc; --accent-2:#a78bfa;
-    --good:#34d399; --warn:#f59e0b; --bad:#f87171; --grid-gap:.6rem
+    --good:#34d399; --warn:#f59e0b; --bad:#f87171; --grid-gap:.8rem
   }
   *{box-sizing:border-box}
   html,body{height:100%}
@@ -17,9 +17,9 @@
   small{color:var(--ink-dim)}
   .app{max-width:1200px; margin:20px auto; padding:12px}
   .topbar{display:grid; grid-template-columns:1fr auto; gap:.5rem; align-items:center; position:sticky; top:0; backdrop-filter:saturate(140%) blur(6px); background:#0f111580; padding:.35rem .5rem; border-radius:10px; border:1px solid #ffffff10}
-  .stat-pill{display:flex; gap:.4rem; align-items:center; background:linear-gradient(180deg,#1b2230,#141822); padding:.35rem .6rem; border:1px solid #ffffff12; border-radius:999px; box-shadow:0 1px 0 #ffffff10 inset; white-space:nowrap}
-  .stat-pill strong{font-size:14px}
-  .pill-row{display:flex; gap:.6rem; flex-wrap:wrap; align-items:center}
+  .stat-pill{display:flex; gap:.4rem; align-items:center; background:linear-gradient(180deg,#1b2230,#141822); padding:.45rem .8rem; border:1px solid #ffffff12; border-radius:999px; box-shadow:0 1px 0 #ffffff10 inset; white-space:nowrap; min-width:115px}
+  .stat-pill strong{font-size:14px; max-width:60px; overflow:hidden; text-overflow:ellipsis; text-align:right}
+  .pill-row{display:flex; gap:.8rem; flex-wrap:wrap; align-items:center}
   .btn{border:1px solid #ffffff1a; background:linear-gradient(180deg,#242b3b,#181d29); color:var(--ink); padding:.45rem .7rem; border-radius:10px; cursor:pointer; transition:transform .05s ease, opacity .2s, background .2s; user-select:none}
   .btn:active{transform:translateY(1px)}
   .btn[disabled]{opacity:.45; cursor:not-allowed; border-color:#ffffff10}
@@ -27,8 +27,8 @@
   .grid{display:grid; gap:var(--grid-gap)}
   .cols-3{grid-template-columns:repeat(3,1fr)}
   .cols-2{grid-template-columns:repeat(2,1fr)}
-  .panel{background:linear-gradient(180deg,var(--panel),var(--panel-2)); border:1px solid #ffffff14; border-radius:14px; padding:.8rem; box-shadow:inset 0 1px 0 #ffffff10}
-  .char{display:grid; grid-template-columns:52px 1fr auto; gap:.6rem; align-items:center}
+  .panel{background:linear-gradient(180deg,var(--panel),var(--panel-2)); border:1px solid #ffffff14; border-radius:14px; padding:1rem; box-shadow:inset 0 1px 0 #ffffff10}
+  .char{display:grid; grid-template-columns:52px 1fr auto; gap:.8rem; align-items:center; min-height:60px}
   .char .svg{width:48px; height:48px; border-radius:12px; background:#0b0f16; display:grid; place-items:center; border:1px solid #ffffff14}
   .char .meta{display:grid; gap:.2rem}
   .role{font-weight:700; letter-spacing:.5px}
@@ -39,11 +39,12 @@
   .bar{height:8px; background:#0c1018; border:1px solid #ffffff14; border-radius:999px; overflow:hidden}
   .bar>i{display:block; height:100%; background:linear-gradient(90deg,#60a5fa,#22d3ee)}
   .kv{display:grid; grid-template-columns:repeat(6,1fr); gap:.4rem; margin-top:.4rem}
-  .kv div{background:#0e1420; border:1px dashed #ffffff12; padding:.35rem .45rem; border-radius:10px; text-align:center; min-height:42px; display:flex; flex-direction:column; align-items:center; justify-content:center; overflow:hidden}
+  .kv div{background:#0e1420; border:1px dashed #ffffff12; padding:.45rem .6rem; border-radius:10px; text-align:center; min-height:42px; display:flex; flex-direction:column; align-items:center; justify-content:center; overflow:hidden}
   .kv b{display:block; font-size:12px; color:var(--ink-dim); white-space:nowrap; text-overflow:ellipsis; overflow:hidden; max-width:100%}
   .section{display:grid; gap:.6rem}
-  .vlist{display:grid; gap:.4rem}
-  .row{display:flex; align-items:center; justify-content:space-between; gap:.6rem}
+  .vlist{display:grid; gap:.6rem}
+  .row{display:flex; align-items:center; justify-content:space-between; gap:.8rem; min-height:52px}
+  .row button{white-space:nowrap; min-width:90px}
   .row .miss{color:var(--bad); font-size:12px}
   .tiny{font-size:12px; color:var(--ink-dim)}
   .codebox{display:flex; gap:.4rem}


### PR DESCRIPTION
## Summary
- lock dashboard pills to fixed width and clamp big numbers
- add padding/gap to panels, rows, and cards for better spacing
- ensure party and upgrade rows keep consistent height

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26385d60c832782d95dc3265b2961