### PR TITLE
Scale enemies with player level

### DIFF
--- a/animal_gacha.html
+++ b/animal_gacha.html
@@ -374,7 +374,7 @@ function autoManageJewelry(){
 
 // ===== Battle & Drops =====
 const spawnEnemy = () => {
-  const lvl = Math.max(1, Math.floor(1 + Math.log10(1+S.gold)*2 + (S.enemy?.level||1)*0.05))
+  const lvl = Math.max(1, partyMinLevel())
   const type = pick(ENEMY_TYPES).id
   const hp = Math.floor(100 + Math.pow(lvl, 1.8) * 18)
   S.enemy = { level:lvl, type, hp, maxHp:hp }
@@ -787,6 +787,13 @@ function runTests(){
   const stBefore = computeUnitStats(testU).effDps; const prevWeapon = testU.bestWeapon; testU.bestWeapon += 100; const stAfter = computeUnitStats(testU).effDps; A(stAfter > stBefore, 'Armory Power (weapon) increases DPS'); testU.bestWeapon = prevWeapon
   const eBefore = computeUnitStats(testU).ehp; const prevArmor = testU.bestArmor; testU.bestArmor += 50; const eAfter = computeUnitStats(testU).ehp; A(eAfter > eBefore, 'Armory Power (armor) increases EHP'); testU.bestArmor = prevArmor
   const m = calcMetrics(); A(m.gph >= 0 && m.tph >= 0 && isFinite(m.kpm), 'calcMetrics returns sane numbers')
+  // Enemy level should track party level
+  const prevLevels = S.active.map(id => S.roster[id].level)
+  S.active.forEach(id => S.roster[id].level = 10)
+  spawnEnemy()
+  A(S.enemy.level >= 10, 'Enemy scales with player level')
+  S.active.forEach((id,i) => S.roster[id].level = prevLevels[i])
+  spawnEnemy()
   // flashSave must be safe without #savestatus
   try { flashSave('ok'); A(true, 'flashSave() null-safe without #savestatus') } catch(e){ A(false, 'flashSave() threw without #savestatus') }
   const passCount = results.filter(r=>r.pass).length


### PR DESCRIPTION
## Summary
- scale enemy level using the party's minimum level to keep fights challenging
- add self-test ensuring enemies scale with player level

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a263bc18508327be9a7efe965b1fc9